### PR TITLE
Sets gray color to match with dark background

### DIFF
--- a/DarkModeRemnote.css
+++ b/DarkModeRemnote.css
@@ -586,46 +586,28 @@
     }
     
     /* Trail History */
-
+    /* Set dark background for the container */
     #thinking-trail-history:hover #thinking-trail-history__container {
         background-color: var(--elevated-background-c); 
-        box-shadow: 0px 0px 4px 0px rgba(0, 0, 0, .5);
-        border-bottom-right-radius: 4px;
-        border-top-right-radius: 4px;
-        margin: 0px;
     }
-    
-    #thinking-trail-history {
-        margin: 2px;
+
+    /* Set blue theme color for the horizontal lines in the history tree */
+    #thinking-trail-history .thinking-trail-history__document .thinking-trail-history__children-bar {
+        color: var(--font-blue-c);
     }
-    
-    #thinking-trail-history .thinking-trail-history__document .thinking-trail-history__document-dot {
-        background-color: var(--font-background-c);
-        border: thin solid var(--font-background-c);
-        border-radius: 2.5px;
-        width: 8px;
-        height: 8px;
+
+    /* Set blue theme color for the vertical lines in the history tree */
+    #thinking-trail-history .thinking-trail-history__document .thinking-trail-history__document-height-offset{        
+        background-color: var(--font-blue-c);
     }
-    
-    #thinking-trail-history .thinking-trail-history__document--active .thinking-trail-history__document-dot,
-    #thinking-trail-history .thinking-trail-history__document--active .thinking-trail-history__document-dot:hover {
-        background-color: var(--font-background-c)!important;
-        border: thin solid var(--font-background-c);
-        border-radius: 2.5px;
-        width: 8px;
-        height: 8px;
-        box-shadow: 0px 0px 4px 0px rgba(254, 254, 254, .5);
-        opacity: 0.5   
+
+    /* Set a dark font color when an item in the document list is hovered */
+    /* Ideally this should be light font on dark background, but */
+    /* no luck in changing hover background to dark */
+    #thinking-trail-history__document-list .thinking-trail-history__document-dot__preview:hover {
+        color: var(--main-background-c);         
     }
-    
-    #thinking-trail-history .thinking-trail-history__document {
-        height: 2em;
-    }
-    
-    #thinking-trail-history .thinking-trail-history__document .thinking-trail-history__document-dot__preview {
-        padding: 2px 7px 0px 5px;
-    }
-    
+
     /* Title */
 
     #document #DocumentTopRow {

--- a/DarkModeRemnote.css
+++ b/DarkModeRemnote.css
@@ -147,6 +147,14 @@
         background-color: transparent;
         letter-spacing: var(--bold-font-spacing);
     }
+
+    /* Set proper gray text color to match with dark background */
+    /* This color is used for breadcrumbs and Rem content of each item inside */
+    /* 'Search Results Window', 'Rem reference preview or tooltip' etc. */
+
+    .gray {
+        color: var(--font-dark-c);
+    }
     
     /* Logo */
 

--- a/DarkModeRemnote.css
+++ b/DarkModeRemnote.css
@@ -951,7 +951,12 @@
         padding: 1px 5px;
         background-color: #50565c;
     }
-    
+
+    /* Set dark background highlight color to the search text when searching for a tag using '##' */    
+   .work-in-progress-tag { 
+        background-color: var(--hover-background-c); 
+    }
+
     /* Links */
 
     .rem-reference-link {

--- a/DarkModeRemnote.css
+++ b/DarkModeRemnote.css
@@ -701,9 +701,9 @@
         box-shadow: none;
     }
     
+    /* Set dark highlight color to the search text when searching for a reference using '[[' */
     .work-in-progress-rem {       
-        background-color: transparent;
-        padding: 0px;
+        background-color: var(--hover-background-c); 
     }
 
     /* References */


### PR DESCRIPTION
- Commit 4af881d : The default gray color in the dark theme looks bit dull in contrast to the dark background, thus making breadcrumbs and rem content hard to read in multiple windows like search results window, rem reference popup (preview/tool tip) window. This commit will set the gray color as the --font-dark-c color from the theme.

- Commit 4741275 : The background color of search text when searching for a tag is white, the commit will change that to --hover-background-c

- Commit 696479a : There is no highlight for the search text when searching for a reference, this is fine, but if someone searches for a reference and then clicks somewhere else, then that rem will get stuck in that 'search mode' (like if you click on that search text the search window will show up). So I thought having some dark highlight that goes well with the theme will help. I actually made this change for myself, but pushed to it master and here we are. 

- Commit 4cd5250 : Attempt to fix the messed up breadcrumbs when it got moved from the top to the left

I think if you have a branch other than master, I can submit pull requests to that without disturbing the master branch. That way you can check the changes and merge with master