### PR TITLE
Set dark background for new inner document container

### DIFF
--- a/DarkModeRemnote.css
+++ b/DarkModeRemnote.css
@@ -166,6 +166,10 @@
     .gray {
         color: var(--font-dark-c);
     }
+    /* Set dark background for the new inner document container */
+    #ExamplesPageContainer #ExamplesPageContent, #export-container #export, #HelpPage #HelpPageContent, #SettingsPage #SettingsPageContent, #sign-up-page-container #sign-up-page, #StatsPage #StatsPageContent, .centered-page, .document--narrow {
+       background-color: var(--main-background-c);
+    }
     
     /* Logo */
 


### PR DESCRIPTION
Looks like there is new document container that comes with light background color. I am submitting this since I see complaints in discord server. I actually made use of your suggestions this time and directly picked the selectors from the inspector. Now I know that it is not that difficult. At the same time feel free to reject this PL if you think this is not the right way, I can still got wrong in the selection of colors. But I think this is a simple change